### PR TITLE
Fix build warnings and update code for .NET 8 nullability

### DIFF
--- a/AboutBox1.cs
+++ b/AboutBox1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -37,7 +37,8 @@ namespace NotePadWF_CS
                         return titleAttribute.Title;
                     }
                 }
-                return System.IO.Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly().CodeBase);
+                // Changed CodeBase to Location below
+                return System.IO.Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly().Location);
             }
         }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -11,10 +11,9 @@ namespace NotePadWF_CS
     {
         private Boolean TextHasChanged = false;
         private String DocumentName = "";
-        private Font MasterFont;
         private String FindTextString = "";
         private int FindLastIndexFound = 0;
-        private string PrintText;
+        private string? PrintText;
         private int StartPage;
         private int NumPages;
         private int PageNumber;
@@ -434,7 +433,9 @@ namespace NotePadWF_CS
         {
             try
             {
-                int LineNum = Convert.ToInt32(Interaction.InputBox("Line number:", "Go to line", "", Location.X + 200, Location.Y + 300));
+                string? lineNumStr = Interaction.InputBox("Line number:", "Go to line", "", Location.X + 200, Location.Y + 300);
+                if (string.IsNullOrEmpty(lineNumStr)) return; // Exit if user cancelled or entered nothing
+                int LineNum = Convert.ToInt32(lineNumStr);
                 if (LineNum <= richTextBox1.Lines.Length)
                 {
                     richTextBox1.SelectionStart = richTextBox1.GetFirstCharIndexFromLine(LineNum - 1);
@@ -711,7 +712,7 @@ namespace NotePadWF_CS
 
         private void findToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            FindTextString = Interaction.InputBox("Find what:", "Find", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300);
+            FindTextString = Interaction.InputBox("Find what:", "Find", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300) ?? "";
             // Find the text from the current cursor position
             FindTextIndex(richTextBox1.SelectionStart, false);
             FindTheText();
@@ -731,8 +732,8 @@ namespace NotePadWF_CS
 
         private void replaceToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string FindWhat = Interaction.InputBox("Find what:", "Replace", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300);
-            string ReplaceWith = Interaction.InputBox("Replace with:", "Replace", "", Location.X + 200, Location.Y + 300);
+            string FindWhat = Interaction.InputBox("Find what:", "Replace", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300) ?? "";
+            string ReplaceWith = Interaction.InputBox("Replace with:", "Replace", "", Location.X + 200, Location.Y + 300) ?? "";
 
             FindTextString = FindWhat;
             // Find text from current cursor position
@@ -746,8 +747,8 @@ namespace NotePadWF_CS
 
         private void replaceAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string FindWhat = Interaction.InputBox("Find what:", "Replace all", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300);
-            string ReplaceWith = Interaction.InputBox("Replace with:", "Replace all", "", Location.X + 200, Location.Y + 300);
+            string FindWhat = Interaction.InputBox("Find what:", "Replace all", richTextBox1.SelectedText, Location.X + 200, Location.Y + 300) ?? "";
+            string ReplaceWith = Interaction.InputBox("Replace with:", "Replace all", "", Location.X + 200, Location.Y + 300) ?? "";
 
             FindTextString = FindWhat;
             FindTextIndex(0, false);

--- a/RichTextBoxExtensions.cs
+++ b/RichTextBoxExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 
 namespace NotePadWF_CS
 {
@@ -42,17 +42,18 @@ namespace NotePadWF_CS
             return richTextBox.GetLineFromCharIndex(richTextBox.SelectionStart) == richTextBox.GetLineFromCharIndex(richTextBox.TextLength);
         }
 
-        private static void RichTextBox_KeyDown(object sender, KeyEventArgs e)
+        private static void RichTextBox_KeyDown(object? sender, KeyEventArgs e) // Changed here
         {
-            var richTextBox = (RichTextBox)sender;
-            if (richTextBox.IsSelectionOnFirstLine() && e.KeyCode == Keys.Up ||
-               richTextBox.IsSelectionOnLastLine() && e.KeyCode == Keys.Down ||
-               richTextBox.IsSelectionAtStart() && (e.KeyCode == Keys.Left || e.KeyCode == Keys.Back) ||
-               richTextBox.IsSelectionAtEnd() && (e.KeyCode == Keys.Right || e.KeyCode == Keys.Delete))
+            if (sender is RichTextBox richTextBox) // Added null check pattern
             {
-                e.Handled = true;
+                if (richTextBox.IsSelectionOnFirstLine() && e.KeyCode == Keys.Up ||
+                   richTextBox.IsSelectionOnLastLine() && e.KeyCode == Keys.Down ||
+                   richTextBox.IsSelectionAtStart() && (e.KeyCode == Keys.Left || e.KeyCode == Keys.Back) ||
+                   richTextBox.IsSelectionAtEnd() && (e.KeyCode == Keys.Right || e.KeyCode == Keys.Delete))
+                {
+                    e.Handled = true;
+                }
             }
         }
-
     }
 }


### PR DESCRIPTION
I've addressed several warnings identified from the .NET 8 build output:

- In RichTextBoxExtensions.cs:
  - Resolved CS8622 by making 'sender' parameter nullable in RichTextBox_KeyDown and adding a null check.
- In AboutBox1.cs:
  - Resolved SYSLIB0012 by replacing obsolete Assembly.CodeBase with Assembly.Location.
- In Form1.cs:
  - Resolved CS0169 by removing the unused MasterFont field.
  - Resolved CS8618 for PrintText by declaring it as string?.
  - Addressed CS8600 in methods using Interaction.InputBox (goTo, find, replace, replaceAll) by handling potential null/empty string returns before use or assignment.

The NETSDK1198 warning regarding the publish profile 'Properties/PublishProfiles/win-arm64.pubxml' could not be programmatically resolved due to inconsistencies preventing file manipulation at that path. You have been advised this warning may persist until you manually ensure the file's presence in the source tree.